### PR TITLE
Added GitHub secret repository post

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,12 @@
         <h2 class="posts-year">2020</h2>
         
         <div class="posts-item">
+            <span class="posts-date">July 16</span>
+            <a class="posts-title" href="https://stuartmccoll.github.io/posts/2020-07-16-github-secret-repository-readme/">Enabling the GitHub Secret Profile README.md</a>
+        </div>
+        
+        
+        <div class="posts-item">
             <span class="posts-date">June 22</span>
             <a class="posts-title" href="https://stuartmccoll.github.io/posts/2020-06-22-attaching-to-list-items-with-sharepoint-rest-api/">Attaching to list items with the Microsoft SharePoint REST API</a>
         </div>

--- a/index.xml
+++ b/index.xml
@@ -6,10 +6,20 @@
     <description>Recent content on Stuart McColl</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en</language>
-    <lastBuildDate>Mon, 22 Jun 2020 16:00:48 +0100</lastBuildDate>
+    <lastBuildDate>Thu, 16 Jul 2020 18:00:00 +0100</lastBuildDate>
     
 	<atom:link href="https://stuartmccoll.github.io/index.xml" rel="self" type="application/rss+xml" />
     
+    
+    <item>
+      <title>Enabling the GitHub Secret Profile README.md</title>
+      <link>https://stuartmccoll.github.io/posts/2020-07-16-github-secret-repository-readme/</link>
+      <pubDate>Thu, 16 Jul 2020 18:00:00 +0100</pubDate>
+      
+      <guid>https://stuartmccoll.github.io/posts/2020-07-16-github-secret-repository-readme/</guid>
+      <description>People on Twitter have recently discovered a GitHub secret. If you create a new GitHub repository with the same name as your profile name, you can add a README.md to your GitHub profile 1.
+How to create a GitHub profile README.md   Create a new GitHub repository. You&amp;rsquo;ll see two mandatory options when creating your repository - the &amp;lsquo;Owner&amp;rsquo; dropdown field and the &amp;lsquo;Repository name&amp;rsquo; input field. Ensure that the &amp;lsquo;Repository name&amp;rsquo; value is the same as the value in the &amp;lsquo;Owner&amp;rsquo; dropdown field.</description>
+    </item>
     
     <item>
       <title>Attaching to list items with the Microsoft SharePoint REST API</title>

--- a/posts/2020-07-16-github-secret-repository-readme/index.html
+++ b/posts/2020-07-16-github-secret-repository-readme/index.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+
+    <head>
+        <meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="ie=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta name="author"
+    content="Stuart McColl ">
+<meta name="description"
+    content="People on Twitter have recently discovered a GitHub secret. If you create a new GitHub repository with the same name as your profile name, you can add a README.md to your GitHub profile 1.
+How to create a GitHub profile README.md   Create a new GitHub repository. You&amp;rsquo;ll see two mandatory options when creating your repository - the &amp;lsquo;Owner&amp;rsquo; dropdown field and the &amp;lsquo;Repository name&amp;rsquo; input field. Ensure that the &amp;lsquo;Repository name&amp;rsquo; value is the same as the value in the &amp;lsquo;Owner&amp;rsquo; dropdown field." />
+<meta name="keywords" content="homepage, blog, development, programming" />
+<meta name="robots" content="noodp" />
+<link rel="canonical" href="https://stuartmccoll.github.io/posts/2020-07-16-github-secret-repository-readme/" />
+<title>
+    Enabling the GitHub Secret Profile README.md :: Stuart McColl 
+</title>
+<link rel="stylesheet" href="/main.min.9b276610b5993837f29d9c1e20b9e04db4f387b683b8034a6bf96f7fbfad81dc.css"><link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/site.webmanifest">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#252627">
+<link rel="shortcut icon" href="/favicon.ico">
+<meta name="theme-color" content="#252627"><meta itemprop="name" content="Enabling the GitHub Secret Profile README.md">
+<meta itemprop="description" content="People on Twitter have recently discovered a GitHub secret. If you create a new GitHub repository with the same name as your profile name, you can add a README.md to your GitHub profile 1.
+How to create a GitHub profile README.md   Create a new GitHub repository. You&rsquo;ll see two mandatory options when creating your repository - the &lsquo;Owner&rsquo; dropdown field and the &lsquo;Repository name&rsquo; input field. Ensure that the &lsquo;Repository name&rsquo; value is the same as the value in the &lsquo;Owner&rsquo; dropdown field.">
+<meta itemprop="datePublished" content="2020-07-16T18:00:00&#43;01:00" />
+<meta itemprop="dateModified" content="2020-07-16T18:00:00&#43;01:00" />
+<meta itemprop="wordCount" content="190">
+<meta itemprop="image" content="https://stuartmccoll.github.io"/>
+
+
+
+<meta itemprop="keywords" content="" /><meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:image" content="https://stuartmccoll.github.io"/>
+
+<meta name="twitter:title" content="Enabling the GitHub Secret Profile README.md"/>
+<meta name="twitter:description" content="People on Twitter have recently discovered a GitHub secret. If you create a new GitHub repository with the same name as your profile name, you can add a README.md to your GitHub profile 1.
+How to create a GitHub profile README.md   Create a new GitHub repository. You&rsquo;ll see two mandatory options when creating your repository - the &lsquo;Owner&rsquo; dropdown field and the &lsquo;Repository name&rsquo; input field. Ensure that the &lsquo;Repository name&rsquo; value is the same as the value in the &lsquo;Owner&rsquo; dropdown field."/>
+
+<meta property="article:published_time" content="2020-07-16 18:00:00 &#43;0100 BST" />
+    </head>
+
+    <body>
+        <div class="container">
+            <header>
+    <section>
+        <h1 class="site-heading">Stuart McColl</h1>
+        <nav>
+            <ul>
+                <li><a href="/">Blog</a></li>
+                <li><a href="/about">About</a></li>
+            </ul>
+        </nav>
+    </section>
+</header>
+
+<hr />
+
+            <div class="content">
+                
+<main class="post">
+
+    <article>
+        <header>
+            <h1 class="post-title">Enabling the GitHub Secret Profile README.md</h1>
+            <p class="post-date">July 16, 2020</p>
+        </header>
+
+        <hr class="post-rule" />
+
+        <div class="post-content">
+            <p>People on Twitter have recently discovered a GitHub <em>secret</em>. If you create a new GitHub repository with the same name as your profile name, you can add a <code>README.md</code> to your GitHub profile <sup id="fnref:1"><a href="#fn:1" class="footnote-ref" role="doc-noteref">1</a></sup>.</p>
+<h2 id="how-to-create-a-github-profile-readmemd">How to create a GitHub profile <code>README.md</code></h2>
+<ol>
+<li>
+<p><a href="https://www.github.com/new">Create a new GitHub repository</a>. You&rsquo;ll see two mandatory options when creating your repository - the &lsquo;<strong>Owner</strong>&rsquo; dropdown field and the &lsquo;<strong>Repository name</strong>&rsquo; input field. Ensure that the &lsquo;<strong>Repository name</strong>&rsquo; value is the same as the value in the &lsquo;<strong>Owner</strong>&rsquo; dropdown field. At the time of writing this feature hasn&rsquo;t rolled out to all users - if it&rsquo;s been enabled for you, you&rsquo;ll see a message displayed beginning &lsquo;You found a secret&rsquo;.</p>
+</li>
+<li>
+<p>Check the &lsquo;<strong>Initialise this repository with a README</strong>&rsquo; checkbox.</p>
+</li>
+<li>
+<p>Click the &lsquo;<strong>Create repository</strong>&rsquo; button.</p>
+</li>
+<li>
+<p>After GitHub creates your repository, you&rsquo;ll be dropped into a view of the default template <code>README.md</code>. Click to edit it and add your own information using markdown <sup id="fnref:2"><a href="#fn:2" class="footnote-ref" role="doc-noteref">2</a></sup>.</p>
+</li>
+<li>
+<p>Commit your changes.</p>
+</li>
+<li>
+<p>Navigate to your own profile page to check it out.</p>
+</li>
+</ol>
+<section class="footnotes" role="doc-endnotes">
+<hr>
+<ol>
+<li id="fn:1" role="doc-endnote">
+<p>You can see my own <code>README.md</code> on <a href="https://github.com/stuartmccoll">my GitHub profile</a>. <a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+</li>
+<li id="fn:2" role="doc-endnote">
+<p>For tips on writing markdown check out <a href="https://www.markdownguide.org">the Markdown Guide</a>. <a href="#fnref:2" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+</li>
+</ol>
+</section>
+
+        </div>
+    </article>
+
+</main>
+
+            </div>
+
+            
+
+            <hr />
+
+            <footer>
+    
+    
+    
+    <section>
+        <h3>Share this content</h3>
+        <p>
+            <a
+                href="https://twitter.com/intent/tweet?url=https://stuartmccoll.github.io%2fposts%2f2020-07-16-github-secret-repository-readme%2f&via=itstuartmccoll&text=I%27m%20reading">
+                Tweet this blog post
+            </a>
+        </p>
+    </section>
+    <hr />
+    
+    
+    
+    <section>
+        <h3>More</h3>
+        <ul>
+            
+            <li>
+                <a
+                    href="https://twitter.com/intent/tweet?text=%40itstuartmccoll%20Hello%2C%20%3Cinsert%20message%20here%3E">
+                    Contact me on Twitter
+                </a>
+            </li>
+            
+            
+            <li>Spotted a bug in the site?
+                <a href="https://github.com/stuartmccoll/hugo-theme-refresh/issues/new">
+                    Raise an issue on GitHub
+                </a>
+            </li>
+            
+            <li>Get notifications of new posts by
+                <a href="https://stuartmccoll.github.io/index.xml">
+                    subscribing to my RSS feed
+                </a>
+            </li>
+            
+            <li>This static site was generated using
+                <a href="https://github.com/gohugoio/hugo/releases/tag/v0.70.0">
+                    Hugo version 0.70.0
+                </a>
+            </li>
+            
+        </ul>
+    </section>
+    <hr />
+    
+    <section>
+        <h3>Attribution</h3>
+        <p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">
+            
+            This blog post <span rel="dct:title">(Enabling the GitHub Secret Profile README.md)</span> is licensed under
+            <a href="https://creativecommons.org/licenses/by/4.0">CC BY 4.0</a>. Any code contained within
+            this article may be subject to other licenses.
+            
+        </p>
+    </section>
+    
+</footer>
+
+            
+        </div>
+    </body>
+
+</html>

--- a/posts/index.html
+++ b/posts/index.html
@@ -53,6 +53,10 @@
     <div class="posts-group">
         <h2 class="posts-year">2020</h2>
         <div class="posts-item">
+            <span class="posts-date">July 16</span>
+            <a class="posts-title" href="https://stuartmccoll.github.io/posts/2020-07-16-github-secret-repository-readme/">Enabling the GitHub Secret Profile README.md</a>
+        </div>
+        <div class="posts-item">
             <span class="posts-date">June 22</span>
             <a class="posts-title" href="https://stuartmccoll.github.io/posts/2020-06-22-attaching-to-list-items-with-sharepoint-rest-api/">Attaching to list items with the Microsoft SharePoint REST API</a>
         </div>

--- a/posts/index.xml
+++ b/posts/index.xml
@@ -5,8 +5,52 @@
         <description>Recent content in Posts on Stuart McColl</description>
         <generator>Hugo -- gohugo.io</generator>
         <language>en</language>
-        <lastBuildDate>Mon, 22 Jun 2020 16:00:48 +0100</lastBuildDate>
+        <lastBuildDate>Thu, 16 Jul 2020 18:00:00 +0100</lastBuildDate>
         <atom:link href="https://stuartmccoll.github.io/posts/index.xml" rel="self" type="application/rss+xml" />
+        
+        <item>
+            <title>Enabling the GitHub Secret Profile README.md</title>
+            <link>https://stuartmccoll.github.io/posts/2020-07-16-github-secret-repository-readme/</link>
+            <pubDate>Thu, 16 Jul 2020 18:00:00 +0100</pubDate>
+            
+            <guid>https://stuartmccoll.github.io/posts/2020-07-16-github-secret-repository-readme/</guid>
+            <description>People on Twitter have recently discovered a GitHub secret. If you create a new GitHub repository with the same name as your profile name, you can add a README.md to your GitHub profile 1.
+How to create a GitHub profile README.md   Create a new GitHub repository. You&amp;rsquo;ll see two mandatory options when creating your repository - the &amp;lsquo;Owner&amp;rsquo; dropdown field and the &amp;lsquo;Repository name&amp;rsquo; input field. Ensure that the &amp;lsquo;Repository name&amp;rsquo; value is the same as the value in the &amp;lsquo;Owner&amp;rsquo; dropdown field.</description>
+            <content type="html"><![CDATA[<p>People on Twitter have recently discovered a GitHub <em>secret</em>. If you create a new GitHub repository with the same name as your profile name, you can add a <code>README.md</code> to your GitHub profile <sup id="fnref:1"><a href="#fn:1" class="footnote-ref" role="doc-noteref">1</a></sup>.</p>
+<h2 id="how-to-create-a-github-profile-readmemd">How to create a GitHub profile <code>README.md</code></h2>
+<ol>
+<li>
+<p><a href="https://www.github.com/new">Create a new GitHub repository</a>. You&rsquo;ll see two mandatory options when creating your repository - the &lsquo;<strong>Owner</strong>&rsquo; dropdown field and the &lsquo;<strong>Repository name</strong>&rsquo; input field. Ensure that the &lsquo;<strong>Repository name</strong>&rsquo; value is the same as the value in the &lsquo;<strong>Owner</strong>&rsquo; dropdown field. At the time of writing this feature hasn&rsquo;t rolled out to all users - if it&rsquo;s been enabled for you, you&rsquo;ll see a message displayed beginning &lsquo;You found a secret&rsquo;.</p>
+</li>
+<li>
+<p>Check the &lsquo;<strong>Initialise this repository with a README</strong>&rsquo; checkbox.</p>
+</li>
+<li>
+<p>Click the &lsquo;<strong>Create repository</strong>&rsquo; button.</p>
+</li>
+<li>
+<p>After GitHub creates your repository, you&rsquo;ll be dropped into a view of the default template <code>README.md</code>. Click to edit it and add your own information using markdown <sup id="fnref:2"><a href="#fn:2" class="footnote-ref" role="doc-noteref">2</a></sup>.</p>
+</li>
+<li>
+<p>Commit your changes.</p>
+</li>
+<li>
+<p>Navigate to your own profile page to check it out.</p>
+</li>
+</ol>
+<section class="footnotes" role="doc-endnotes">
+<hr>
+<ol>
+<li id="fn:1" role="doc-endnote">
+<p>You can see my own <code>README.md</code> on <a href="https://github.com/stuartmccoll">my GitHub profile</a>. <a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+</li>
+<li id="fn:2" role="doc-endnote">
+<p>For tips on writing markdown check out <a href="https://www.markdownguide.org">the Markdown Guide</a>. <a href="#fnref:2" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+</li>
+</ol>
+</section>
+]]></content>
+        </item>
         
         <item>
             <title>Attaching to list items with the Microsoft SharePoint REST API</title>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,6 +3,21 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   
   <url>
+    <loc>https://stuartmccoll.github.io/posts/2020-07-16-github-secret-repository-readme/</loc>
+    <lastmod>2020-07-16T18:00:00+01:00</lastmod>
+  </url>
+  
+  <url>
+    <loc>https://stuartmccoll.github.io/posts/</loc>
+    <lastmod>2020-07-16T18:00:00+01:00</lastmod>
+  </url>
+  
+  <url>
+    <loc>https://stuartmccoll.github.io/</loc>
+    <lastmod>2020-07-16T18:00:00+01:00</lastmod>
+  </url>
+  
+  <url>
     <loc>https://stuartmccoll.github.io/tags/api/</loc>
     <lastmod>2020-06-22T16:00:48+01:00</lastmod>
   </url>
@@ -23,22 +38,12 @@
   </url>
   
   <url>
-    <loc>https://stuartmccoll.github.io/posts/</loc>
-    <lastmod>2020-06-22T16:00:48+01:00</lastmod>
-  </url>
-  
-  <url>
     <loc>https://stuartmccoll.github.io/tags/rest/</loc>
     <lastmod>2020-06-22T16:00:48+01:00</lastmod>
   </url>
   
   <url>
     <loc>https://stuartmccoll.github.io/tags/sharepoint/</loc>
-    <lastmod>2020-06-22T16:00:48+01:00</lastmod>
-  </url>
-  
-  <url>
-    <loc>https://stuartmccoll.github.io/</loc>
     <lastmod>2020-06-22T16:00:48+01:00</lastmod>
   </url>
   


### PR DESCRIPTION
This pull request adds a post covering how to enable the GitHub secret profile `README.md` repository.