### PR TITLE
Updated Git submodule reference to use HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/hugo-theme-refresh"]
 	path = themes/hugo-theme-refresh
-	url = git@github.com:stuartmccoll/hugo-theme-refresh.git
+	url = https://github.com/stuartmccoll/hugo-theme-refresh.git


### PR DESCRIPTION
This commit updates the Git submodule reference for the site's theme to use HTTPS, as this is required by GitHub pages.