### PR TITLE
Updated documentation and removed publishDir config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,18 @@ site, execute the following command in your terminal:
 hugo
 ```
 
-If successful, this will re-populate the `docs` directory.
+If successful, this will re-populate the `public` directory if it already
+exists, or create and populate it if not.
 
-### GitHub Codespaces
+## Deployment
+
+This site is deployed via a GitHub Action.
+
+Upon merge of a pull request into the `main` branch, the GitHub Action
+will update the `gh-pages` branch with the latest build of the static files.
+This branch is then served via GitHub Pages.
+
+## GitHub Codespaces
 
 This repository contains all of the necessary configuration to run in a GitHub
 Codespace.

--- a/config.toml
+++ b/config.toml
@@ -3,10 +3,6 @@ title = "Stuart McColl"
 languageCode = "en"
 theme = "hugo-theme-refresh"
 
-# GitHub Pages doesn't allow for a custom source directory,
-# so we use their non-root default of 'docs'
-publishDir = "docs"
-
 pygmentsStyle = "github"
 pygmentsUseClasses = true
 pygmentsCodeFencers = true


### PR DESCRIPTION
This commit updates the documentation to reflect removal of the `publishDir` configuration, which is no longer needed now that the GitHub Action is building and deploying the static files.