### PR TITLE
Add Application Insights

### DIFF
--- a/.azure/bicep/application-insights.bicep
+++ b/.azure/bicep/application-insights.bicep
@@ -1,0 +1,38 @@
+@description('Location for all resources')
+param location string = resourceGroup().location
+
+var tags = {
+  resource: 'blog'
+}
+
+resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: 'logBlogApplicationInsightsWorkspace'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+  tags: tags
+}
+
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: 'appiBlog'
+  kind: 'web'
+  location: location
+  properties: {
+    Application_Type: 'web'
+    Flow_Type: 'Bluefield'
+    IngestionMode: 'LogAnalytics'
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+    Request_Source: 'rest'
+    RetentionInDays: 90
+    WorkspaceResourceId: workspace.id
+  }
+  tags: tags
+}
+
+output applicationInsightsInstrumentationKey string = applicationInsights.properties.InstrumentationKey
+output applicationInsightsConnectionString string = applicationInsights.properties.ConnectionString

--- a/config.toml
+++ b/config.toml
@@ -50,6 +50,12 @@ pygmentsCodeFencers = true
   # Flag to toggle inclusion of Hugo version details
   includeHugoVersion = true
 
+  # Flag to toggle inclusion of Azure Application Insights
+  includeApplicationInsights = true
+
+  # Azure Application Insights connection string
+  applicationInsightsConnectionString = "InstrumentationKey=74cc5c48-d066-4928-932e-459f438b579d;IngestionEndpoint=https://uksouth-1.in.applicationinsights.azure.com/;LiveEndpoint=https://uksouth.livediagnostics.monitor.azure.com/"
+
 [markup]
   [markup.highlight]
   codeFences = true


### PR DESCRIPTION
This pull request:

- updates the theme submodule.
- updates the `config.toml` file to include Azure Application Insights configuration.
- adds a Bicep template for deploying an Application Insights resource to Azure.